### PR TITLE
Fix problem with plugins crash if no help_tabs

### DIFF
--- a/src/tabs.php
+++ b/src/tabs.php
@@ -15,10 +15,10 @@ if (in_array('help', reset($tabs))) {
     /*
      * Remove help tab.
      */
-    add_action('admin_head', function () {
-        $screen = get_current_screen();
+    add_filter('contextual_help', function ($old_help, $screen_id, $screen) {
         $screen->remove_help_tabs();
-    });
+        return $old_help;
+    }, 999, 3);
 }
 
 if (in_array('screen-options', reset($tabs))) {

--- a/src/tabs.php
+++ b/src/tabs.php
@@ -17,6 +17,7 @@ if (in_array('help', reset($tabs))) {
      */
     add_filter('contextual_help', function ($old_help, $screen_id, $screen) {
         $screen->remove_help_tabs();
+
         return $old_help;
     }, 999, 3);
 }


### PR DESCRIPTION
This fixes issue with WooCommerce crashing on install because there are no help tabs.
