### PR TITLE
Fix errors in fakerpress admin page

### DIFF
--- a/src/editor.php
+++ b/src/editor.php
@@ -42,8 +42,8 @@ add_action('admin_menu', function () {
 add_filter('sanitize_file_name', function ($name) {
     $path = pathinfo($name);
 
-    if(!isset($path['extension'])) {
-      return $name;
+    if (!isset($path['extension'])) {
+        return $name;
     }
 
     $filename = preg_replace(sprintf('/.%s$/', $path['extension']), '', $name);

--- a/src/editor.php
+++ b/src/editor.php
@@ -42,8 +42,7 @@ add_action('admin_menu', function () {
 add_filter('sanitize_file_name', function ($name) {
     $path = pathinfo($name);
 
-    if(!isset($path['extension']))
-    {
+    if(!isset($path['extension'])) {
       return $name;
     }
 

--- a/src/editor.php
+++ b/src/editor.php
@@ -42,7 +42,10 @@ add_action('admin_menu', function () {
 add_filter('sanitize_file_name', function ($name) {
     $path = pathinfo($name);
 
-    if(!isset($path['extension'])) return $name;
+    if(!isset($path['extension']))
+    {
+      return $name;
+    }
 
     $filename = preg_replace(sprintf('/.%s$/', $path['extension']), '', $name);
 

--- a/src/editor.php
+++ b/src/editor.php
@@ -42,6 +42,8 @@ add_action('admin_menu', function () {
 add_filter('sanitize_file_name', function ($name) {
     $path = pathinfo($name);
 
+    if(!isset($path['extension'])) return $name;
+
     $filename = preg_replace(sprintf('/.%s$/', $path['extension']), '', $name);
 
     return sprintf('%s.%s', Str::slug($filename), $path['extension']);


### PR DESCRIPTION
```
Notice: Undefined index: extension in .../plugins/plate/src/editor.php on line 47
```

This errors come out when in `/wp-admin/admin.php?page=fakerpress`.

Somehow wordpress pass value `settings` to the `sanitize_file_name` filter. So there are no extension. I debug it as below.
```
array:2 [▼
  "name" => "settings"
  "pathinfo" => array:3 [▼
    "dirname" => "."
    "basename" => "settings"
    "filename" => "settings"
  ]
]
```