### PR TITLE
Use remove_menu_page in plate-menu instead of hiding with css

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Below is a list of handy helpers this plugins provides.
 
 #### `plate-menu`
 
-This feature accepts an array of menu items you want to hide in the WordPress administrator dashboard.
+This feature accepts an array of slugs for menu items you want to hide in the WordPress administrator dashboard.
 
 ```php
 add_theme_support('plate-menu', [
-   'comments',
-   'dashboard',
-   'links',
-   'media',
+    'edit-comments.php', // comments
+    'index.php', // dashboard
+    'link-manager.php', // links
+    'upload.php', // media
 ]);
 ```
 

--- a/src/menu.php
+++ b/src/menu.php
@@ -12,10 +12,10 @@
 declare(strict_types=1);
 
 // Remove menu items.
-add_action('admin_head', function () {
+add_action('admin_menu', function () {
     $items = get_theme_support('plate-menu');
 
-    $elements = implode(', #menu-', reset($items));
-
-    echo sprintf('<style> #menu-%s { display: none !important; } </style>', $elements);
+    foreach(reset($items) as $item) {
+        remove_menu_page($item);
+    }
 });

--- a/src/menu.php
+++ b/src/menu.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 add_action('admin_menu', function () {
     $items = get_theme_support('plate-menu');
 
-    foreach(reset($items) as $item) {
+    foreach (reset($items) as $item) {
         remove_menu_page($item);
     }
 });


### PR DESCRIPTION
Issue: "#menu-" prefix isn't used by menu items added by plugins/theme, so they couldn't be hidden