### PR TITLE
Add support for plugin pages, increase priority

### DIFF
--- a/src/menu.php
+++ b/src/menu.php
@@ -31,7 +31,7 @@ add_action('admin_menu', function () {
         if (isset($value[1])) {
             $name = $value[1];
 
-            strpos($item, 'admin.php') ?  remove_submenu_page($path, $name) : remove_menu_page($name);
+            strpos($item, 'admin.php') ? remove_submenu_page($path, $name) : remove_menu_page($name);
         }
     }
 }, PHP_INT_MAX);

--- a/src/menu.php
+++ b/src/menu.php
@@ -16,28 +16,22 @@ add_action('admin_menu', function () {
     $items = get_theme_support('plate-menu');
 
     foreach (reset($items) as $item) {
-        if (strpos($item, '?') !== false) {
-            // edit.php?post_type=foo should be removed with remove_menu_page('edit.php?post_type=foo')
-            if (strpos($item, 'edit.php?post_type=') === 0) {
-                remove_menu_page($item);
-            } else {
-
-                $path = parse_url($item, PHP_URL_PATH);
-                $query = parse_url($item, PHP_URL_QUERY);
-                $query_value = explode('=', $query);
-                if (isset($query_value[1])) {
-                    $pageName = $query_value[1];
-
-                    // admin.php?page=foo should be removed with remove_menu_page('foo')
-                    if (strpos($item, 'admin.php') === 0) {
-                        remove_menu_page($pageName);
-                    } else {
-                        remove_submenu_page($path, $pageName);
-                    }
-                }
-            }
-        } else {
+        if (
+            !strpos($item, '?') ||
+            !strpos($item, 'edit.php?post_type=')
+        ) {
             remove_menu_page($item);
+            continue;
+        }
+
+        $path = parse_url($item, PHP_URL_PATH);
+        $query = parse_url($item, PHP_URL_QUERY);
+        $value = explode('=', $query);
+
+        if (isset($value[1])) {
+            $name = $value[1];
+
+            strpos($item, 'admin.php') ?  remove_submenu_page($path, $name) : remove_menu_page($name);
         }
     }
 }, PHP_INT_MAX);

--- a/src/menu.php
+++ b/src/menu.php
@@ -11,11 +11,33 @@
 
 declare(strict_types=1);
 
-// Remove menu items.
+// Remove menu and submenu items.
 add_action('admin_menu', function () {
     $items = get_theme_support('plate-menu');
 
     foreach (reset($items) as $item) {
-        remove_menu_page($item);
+        if (strpos($item, '?') !== false) {
+            // edit.php?post_type=foo should be removed with remove_menu_page('edit.php?post_type=foo')
+            if (strpos($item, 'edit.php?post_type=') === 0) {
+                remove_menu_page($item);
+            } else {
+
+                $path = parse_url($item,  PHP_URL_PATH);
+                $query = parse_url($item,  PHP_URL_QUERY);
+                $query_value = explode('=', $query);
+                if (isset($query_value[1])) {
+                    $pageName = $query_value[1];
+
+                    // admin.php?page=foo should be removed with remove_menu_page('foo')
+                    if (strpos($item, 'admin.php') === 0) {
+                        remove_menu_page($pageName);
+                    } else {
+                        remove_submenu_page($path, $pageName);
+                    }
+                }
+            }
+        } else {
+            remove_menu_page($item);
+        }
     }
-});
+}, PHP_INT_MAX);

--- a/src/menu.php
+++ b/src/menu.php
@@ -22,8 +22,8 @@ add_action('admin_menu', function () {
                 remove_menu_page($item);
             } else {
 
-                $path = parse_url($item,  PHP_URL_PATH);
-                $query = parse_url($item,  PHP_URL_QUERY);
+                $path = parse_url($item, PHP_URL_PATH);
+                $query = parse_url($item, PHP_URL_QUERY);
                 $query_value = explode('=', $query);
                 if (isset($query_value[1])) {
                     $pageName = $query_value[1];

--- a/src/menu.php
+++ b/src/menu.php
@@ -17,8 +17,8 @@ add_action('admin_menu', function () {
 
     foreach (reset($items) as $item) {
         if (
-            !strpos($item, '?') ||
-            !strpos($item, 'edit.php?post_type=')
+            strpos($item, '?') === false ||
+            strpos($item, 'edit.php?post_type=') === 0
         ) {
             remove_menu_page($item);
             continue;
@@ -31,7 +31,7 @@ add_action('admin_menu', function () {
         if (isset($value[1])) {
             $name = $value[1];
 
-            strpos($item, 'admin.php') ? remove_submenu_page($path, $name) : remove_menu_page($name);
+            strpos($item, 'admin.php') !== 0 ? remove_submenu_page($path, $name) : remove_menu_page($name);
         }
     }
 }, PHP_INT_MAX);


### PR DESCRIPTION
Issues:
This helper didn't work for `'tools.php?page=wp-migrate-db'` or 'admin.php?page=theseoframework-settings'.
The SEO Framework added it's menu item with a higher priority than this helper.

This closes #7 