### PR TITLE
We should not disable the REST API

### DIFF
--- a/src/disable-api.php
+++ b/src/disable-api.php
@@ -12,14 +12,14 @@
 declare(strict_types=1);
 
 // Require authentication for all requests for the REST API.
-add_filter('rest_authentication_errors', function($result) {
+add_filter('rest_authentication_errors', function ($result) {
     if (!empty($result)) {
         return $result;
     }
-    
+
     if (!is_user_logged_in()) {
         return new WP_Error('rest_not_logged_in', 'You are not currently logged in.', ['status' => 401]);
     }
-    
+
     return $result;
 });

--- a/src/disable-api.php
+++ b/src/disable-api.php
@@ -11,4 +11,15 @@
 
 declare(strict_types=1);
 
-remove_action('rest_api_init', 'create_initial_rest_routes', 99);
+// Require authentication for all requests for the REST API.
+add_filter('rest_authentication_errors', function($result) {
+    if (!empty($result)) {
+        return $result;
+    }
+    
+    if (!is_user_logged_in()) {
+        return new WP_Error('rest_not_logged_in', 'You are not currently logged in.', ['status' => 401]);
+    }
+    
+    return $result;
+});


### PR DESCRIPTION
"You should not disable the REST API, because doing so would break future WordPress Admin functionality that will depend on the API being active. However, you may use a filter to require that API consumers be authenticated, which effectively prevents anonymous external access." 

Source: https://developer.wordpress.org/rest-api/using-the-rest-api/frequently-asked-questions/#can-i-disable-the-rest-api